### PR TITLE
chore(release): 1.0.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flowbuild/react-mqtt-workflow-manager",
-  "version": "0.1.0",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flowbuild/react-mqtt-workflow-manager",
-      "version": "0.1.0",
+      "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowbuild/react-mqtt-workflow-manager",
-  "version": "0.1.0",
+  "version": "1.0.0-alpha.1",
   "license": "MIT",
   "description": "A react wrapper manager for MQTT",
   "repository": "https://github.com/flow-build/react-mqtt-workflow-manager",


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.0-alpha.1](https://github.com/flow-build/react-mqtt-workflow-manager/releases/tag/v1.0.0-alpha.1)